### PR TITLE
Improve robustness and CLI parsing

### DIFF
--- a/bin/batch-landscape.js
+++ b/bin/batch-landscape.js
@@ -1,16 +1,24 @@
 #!/usr/bin/env node
 import fs from 'fs';
 import path from 'path';
+import { Command } from 'commander';
 import { loadAllSummaries } from '../lib/loadJsonSummaries.js';
 import { getPromptForImage } from '../lib/matchImageToSummary.js';
 import { editImage } from '../lib/editImage.js';
 
-const [,, originalsDir, jsonDir, maskPath, outDir] = process.argv;
+const program = new Command();
+program
+  .name('batch-landscape')
+  .argument('<originalsDir>')
+  .argument('<jsonDir>')
+  .argument('<mask>')
+  .argument('<outputDir>')
+  .option('-s, --size <size>', 'image size', '1536x1024')
+  .showHelpAfterError();
 
-if (!originalsDir || !jsonDir || !maskPath || !outDir) {
-  console.error('Usage: batch-landscape <originalsDir> <jsonDir> <mask.png> <outputDir>');
-  process.exit(1);
-}
+program.parse(process.argv);
+const [originalsDir, jsonDir, maskPath, outDir] = program.args;
+const options = program.opts();
 
 if (!fs.existsSync(outDir)) {
   fs.mkdirSync(outDir, { recursive: true });
@@ -26,7 +34,7 @@ const images = fs.readdirSync(originalsDir).filter(f => /\.(png|jpg|jpeg)$/i.tes
     try {
       const prompt = getPromptForImage(img, summaries);
       console.log(`→ Processing ${img} with prompt: ${prompt.slice(0, 80)}...`);
-      await editImage({ imagePath, maskPath, prompt, outPath });
+      await editImage({ imagePath, maskPath, prompt, outPath, size: options.size });
       console.log(`✓ Saved landscape version to: ${outPath}`);
     } catch (e) {
       console.error(`✗ Skipped ${img}:`, e.message);

--- a/lib/editImage.js
+++ b/lib/editImage.js
@@ -5,17 +5,22 @@ dotenv.config();
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
-export async function editImage({ imagePath, maskPath, prompt, outPath }) {
-  const response = await openai.images.edit({
-    model: 'gpt-image-1',
-    image: fs.createReadStream(imagePath),
-    mask: fs.createReadStream(maskPath),
-    prompt,
-    size: '1536x1024',
-    response_format: 'b64_json',
-  });
+export async function editImage({ imagePath, maskPath, prompt, outPath, size = '1536x1024' }) {
+  try {
+    const response = await openai.images.edit({
+      model: 'gpt-image-1',
+      image: fs.createReadStream(imagePath),
+      mask: fs.createReadStream(maskPath),
+      prompt,
+      size,
+      response_format: 'b64_json',
+    });
 
-  const b64 = response.data[0].b64_json;
-  const buffer = Buffer.from(b64, 'base64');
-  fs.writeFileSync(outPath, buffer);
+    const b64 = response.data[0].b64_json;
+    const buffer = Buffer.from(b64, 'base64');
+    fs.writeFileSync(outPath, buffer);
+  } catch (err) {
+    console.error('OpenAI API error:', err.message);
+    throw err;
+  }
 }

--- a/lib/loadJsonSummaries.js
+++ b/lib/loadJsonSummaries.js
@@ -5,8 +5,13 @@ export function loadAllSummaries(jsonFolder) {
   const files = fs.readdirSync(jsonFolder).filter(f => f.endsWith('.json'));
   let summaries = [];
   for (const file of files) {
-    const data = JSON.parse(fs.readFileSync(path.join(jsonFolder, file)));
-    summaries.push(...data);
+    try {
+      const raw = fs.readFileSync(path.join(jsonFolder, file), 'utf8');
+      const data = JSON.parse(raw);
+      summaries.push(...data);
+    } catch (err) {
+      console.warn(`Warning: failed to parse ${file}: ${err.message}`);
+    }
   }
   return summaries;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,21 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "commander": "^11.0.0",
         "dotenv": "^17.2.0",
         "openai": "^5.10.1"
       },
       "bin": {
         "batch-landscape": "bin/batch-landscape.js"
+      }
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/dotenv": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
+    "commander": "^11.0.0",
     "dotenv": "^17.2.0",
     "openai": "^5.10.1"
   }


### PR DESCRIPTION
## Summary
- handle malformed JSON files gracefully
- catch OpenAI API errors in editImage
- switch CLI to commander and add `--size` option
- include commander dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6879b5b1438883268edf747f5284c1cb