### PR TITLE
Improve robustness and CLI parsing

### DIFF
--- a/lib/editImage.js
+++ b/lib/editImage.js
@@ -5,17 +5,22 @@ dotenv.config();
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
-export async function editImage({ imagePath, maskPath, prompt, outPath }) {
-  const response = await openai.images.edit({
-    model: 'gpt-image-1',
-    image: fs.createReadStream(imagePath),
-    mask: fs.createReadStream(maskPath),
-    prompt,
-    size: '1536x1024',
-    response_format: 'b64_json',
-  });
+export async function editImage({ imagePath, maskPath, prompt, outPath, size = '1536x1024' }) {
+  try {
+    const response = await openai.images.edit({
+      model: 'gpt-image-1',
+      image: fs.createReadStream(imagePath),
+      mask: fs.createReadStream(maskPath),
+      prompt,
+      size,
+      response_format: 'b64_json',
+    });
 
-  const b64 = response.data[0].b64_json;
-  const buffer = Buffer.from(b64, 'base64');
-  fs.writeFileSync(outPath, buffer);
+    const b64 = response.data[0].b64_json;
+    const buffer = Buffer.from(b64, 'base64');
+    fs.writeFileSync(outPath, buffer);
+  } catch (err) {
+    console.error('OpenAI API error:', err.message);
+    throw err;
+  }
 }

--- a/lib/loadJsonSummaries.js
+++ b/lib/loadJsonSummaries.js
@@ -5,8 +5,13 @@ export function loadAllSummaries(jsonFolder) {
   const files = fs.readdirSync(jsonFolder).filter(f => f.endsWith('.json'));
   let summaries = [];
   for (const file of files) {
-    const data = JSON.parse(fs.readFileSync(path.join(jsonFolder, file)));
-    summaries.push(...data);
+    try {
+      const raw = fs.readFileSync(path.join(jsonFolder, file), 'utf8');
+      const data = JSON.parse(raw);
+      summaries.push(...data);
+    } catch (err) {
+      console.warn(`Warning: failed to parse ${file}: ${err.message}`);
+    }
   }
   return summaries;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,21 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "commander": "^11.0.0",
         "dotenv": "^17.2.0",
         "openai": "^5.10.1"
       },
       "bin": {
         "batch-landscape": "bin/batch-landscape.js"
+      }
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/dotenv": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
+    "commander": "^11.0.0",
     "dotenv": "^17.2.0",
     "openai": "^5.10.1"
   }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,3 +1,5 @@
+import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { test } from 'node:test';
 import { strictEqual } from 'node:assert';
@@ -16,4 +18,27 @@ test('CLI shows usage on missing args', () => {
   }
   strictEqual(exitCode, 1);
   strictEqual(/Usage: batch-landscape/.test(output), true);
+});
+
+test('CLI fails when provided paths are invalid', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-'));
+  const promptsDir = path.join(tmp, 'json');
+  fs.mkdirSync(promptsDir);
+  const maskPath = path.join(tmp, 'mask.png');
+  fs.writeFileSync(maskPath, '');
+  const outDir = path.join(tmp, 'out');
+
+  let output = '';
+  let exitCode = 0;
+  try {
+    execFileSync('node', [cli, path.join(tmp, 'missing'), promptsDir, maskPath, outDir], {
+      stdio: 'pipe',
+      env: { ...process.env, OPENAI_API_KEY: 'x' }
+    });
+  } catch (err) {
+    output = err.stderr.toString();
+    exitCode = err.status;
+  }
+  strictEqual(exitCode, 1);
+  strictEqual(/Missing originalsDir/.test(output), true);
 });


### PR DESCRIPTION
## Summary
- handle malformed JSON files gracefully
- catch OpenAI API errors in editImage
- switch CLI to commander and add `--size` option
- validate input paths before processing
- include commander dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6879b5b1438883268edf747f5284c1cb