### PR TITLE
Improve JSON parsing and CLI

### DIFF
--- a/bin/batch-landscape.js
+++ b/bin/batch-landscape.js
@@ -1,16 +1,26 @@
 #!/usr/bin/env node
 import fs from 'fs';
 import path from 'path';
+import { Command } from 'commander';
 import { loadAllSummaries } from '../lib/loadJsonSummaries.js';
 import { getPromptForImage } from '../lib/matchImageToSummary.js';
 import { editImage } from '../lib/editImage.js';
 
-const [,, originalsDir, promptsDir, maskPath, outDir] = process.argv;
+const program = new Command();
+program
+  .name('batch-landscape')
+  .usage('<originalsDir> <promptsDir> <mask.png> <outputDir> [options]')
+  .description('Batch convert images to landscape format using OpenAI')
+  .showHelpAfterError()
+  .argument('<originalsDir>', 'directory of source images')
+  .argument('<promptsDir>', 'directory of prompt JSON files')
+  .argument('<maskPath>', 'shared mask PNG')
+  .argument('<outputDir>', 'directory for generated images')
+  .option('-s, --size <size>', 'output image size', '1536x1024')
+  .parse();
 
-if (!originalsDir || !promptsDir || !maskPath || !outDir) {
-  console.error('Usage: batch-landscape <originalsDir> <promptsDir> <mask.png> <outputDir>');
-  process.exit(1);
-}
+const [originalsDir, promptsDir, maskPath, outDir] = program.args;
+const { size } = program.opts();
 
 function ensureDir(name, dir) {
   if (!fs.existsSync(dir)) {
@@ -31,7 +41,7 @@ function ensureFile(name, file) {
 }
 
 ensureDir('originalsDir', originalsDir);
-ensureDir('jsonDir', jsonDir);
+ensureDir('promptsDir', promptsDir);
 ensureFile('maskPath', maskPath);
 
 if (!fs.existsSync(outDir)) {
@@ -46,9 +56,7 @@ if (!fs.existsSync(outDir)) {
   process.exit(1);
 }
 
-
-const summaries = loadAllSummaries(jsonDir);
-
+const summaries = loadAllSummaries(promptsDir);
 const images = fs.readdirSync(originalsDir).filter(f => /\.(png|jpg|jpeg)$/i.test(f));
 
 (async () => {
@@ -58,7 +66,7 @@ const images = fs.readdirSync(originalsDir).filter(f => /\.(png|jpg|jpeg)$/i.tes
     try {
       const prompt = getPromptForImage(img, summaries);
       console.log(`→ Processing ${img} with prompt: ${prompt.slice(0, 80)}...`);
-      await editImage({ imagePath, maskPath, prompt, outPath });
+      await editImage({ imagePath, maskPath, prompt, outPath, size });
       console.log(`✓ Saved landscape version to: ${outPath}`);
     } catch (e) {
       console.error(`✗ Skipped ${img}:`, e.message);

--- a/lib/editImage.js
+++ b/lib/editImage.js
@@ -1,21 +1,30 @@
 import fs from 'fs';
+import path from 'path';
 import { OpenAI } from 'openai';
 import dotenv from 'dotenv';
 dotenv.config();
 
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
-export async function editImage({ imagePath, maskPath, prompt, outPath }) {
-  const response = await openai.images.edit({
-    model: 'gpt-image-1',
-    image: fs.createReadStream(imagePath),
-    mask: fs.createReadStream(maskPath),
-    prompt,
-    size: '1536x1024',
-    response_format: 'b64_json',
-  });
+export async function editImage({ imagePath, maskPath, prompt, outPath, size = '1536x1024' }) {
+  try {
+    const response = await openai.images.edit({
+      model: 'gpt-image-1',
+      image: fs.createReadStream(imagePath),
+      mask: fs.createReadStream(maskPath),
+      prompt,
+      size,
+      response_format: 'b64_json',
+    });
 
-  const b64 = response.data[0].b64_json;
-  const buffer = Buffer.from(b64, 'base64');
-  fs.writeFileSync(outPath, buffer);
+    const b64 = response.data[0].b64_json;
+    const buffer = Buffer.from(b64, 'base64');
+    fs.writeFileSync(outPath, buffer);
+  } catch (err) {
+    console.error(`OpenAI API error for ${path.basename(imagePath)}: ${err.message}`);
+    if (err.response) {
+      console.error(`Status ${err.response.status}: ${JSON.stringify(err.response.data)}`);
+    }
+    throw err;
+  }
 }

--- a/lib/loadJsonSummaries.js
+++ b/lib/loadJsonSummaries.js
@@ -5,8 +5,15 @@ export function loadAllSummaries(jsonFolder) {
   const files = fs.readdirSync(jsonFolder).filter(f => f.endsWith('.json'));
   let summaries = [];
   for (const file of files) {
-    const data = JSON.parse(fs.readFileSync(path.join(jsonFolder, file)));
-    summaries.push(...data);
+    const filePath = path.join(jsonFolder, file);
+    try {
+      const text = fs.readFileSync(filePath, 'utf8');
+      const data = JSON.parse(text);
+      summaries.push(...data);
+    } catch (err) {
+      console.error(`Failed to parse ${filePath}: ${err.message}`);
+      // skip malformed file but continue processing others
+    }
   }
   return summaries;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,21 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "commander": "^11.0.0",
         "dotenv": "^17.2.0",
         "openai": "^5.10.1"
       },
       "bin": {
         "batch-landscape": "bin/batch-landscape.js"
+      }
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/dotenv": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
+    "commander": "^11.0.0",
     "dotenv": "^17.2.0",
     "openai": "^5.10.1"
   }


### PR DESCRIPTION
## Summary
- add commander for CLI parsing and a new `--size` option
- robustly parse JSON prompt files and log errors
- catch and log OpenAI API failures during image edits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6879babcd6388326ad12a95e45379227